### PR TITLE
Update CssAtMediaStartToken.php

### DIFF
--- a/src/tokens/CssAtMediaStartToken.php
+++ b/src/tokens/CssAtMediaStartToken.php
@@ -11,6 +11,7 @@
  */
 class CssAtMediaStartToken extends aCssAtBlockStartToken
 	{
+	public $MediaTypes = [];
 	/**
 	 * Sets the properties of the @media at-rule.
 	 * 


### PR DESCRIPTION
This avoids a deprecation error using PHP > 8.2
Newer versions of PHP do not allow creating dynamic properties